### PR TITLE
i/6536: Added the SelectAll plugin to the essential editor features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The [`Essentials`](https://ckeditor.com/docs/ckeditor5/latest/api/module_essenti
 
 * [`Clipboard`](https://ckeditor.com/docs/ckeditor5/latest/api/module_clipboard_clipboard-Clipboard.html)
 * [`Enter`](https://ckeditor.com/docs/ckeditor5/latest/api/module_enter_enter-Enter.html)
+* [`SelectAll`](https://ckeditor.com/docs/ckeditor5/latest/api/module_select-all_selectall-SelectAll.html)
 * [`Typing`](https://ckeditor.com/docs/ckeditor5/latest/api/module_typing_typing-Typing.html)
 * [`Undo`](https://ckeditor.com/docs/ckeditor5/latest/api/module_undo_undo-Undo.html)
 

--- a/docs/api/essentials.md
+++ b/docs/api/essentials.md
@@ -8,7 +8,7 @@ category: api-reference
 
 Essential editing features for CKEditor 5 wrapped in one plugin.
 
-The {@link module:essentials/essentials~Essentials} plugin exposed by this package enables {@link module:clipboard/clipboard~Clipboard clipboard}, {@link module:enter/enter~Enter Enter}, {@link module:enter/shiftenter~ShiftEnter ShiftEnter}, {@link module:typing/typing~Typing typing} and {@link module:undo/undo~Undo undo} support.
+The {@link module:essentials/essentials~Essentials} plugin exposed by this package enables {@link module:clipboard/clipboard~Clipboard clipboard}, {@link module:enter/enter~Enter Enter}, {@link module:select-all/selectall~SelectAll select all}, {@link module:enter/shiftenter~ShiftEnter ShiftEnter}, {@link module:typing/typing~Typing typing} and {@link module:undo/undo~Undo undo} support.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ckeditor/ckeditor5-clipboard": "^18.0.0",
     "@ckeditor/ckeditor5-core": "^18.0.0",
     "@ckeditor/ckeditor5-enter": "^18.0.0",
+    "@ckeditor/ckeditor5-select-all": "^0.0.1",
     "@ckeditor/ckeditor5-typing": "^18.0.0",
     "@ckeditor/ckeditor5-undo": "^18.0.0"
   },

--- a/src/essentials.js
+++ b/src/essentials.js
@@ -12,6 +12,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
+import SelectAll from '@ckeditor/ckeditor5-select-all/src/selectall';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 
@@ -23,6 +24,7 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
  *
  * * {@link module:clipboard/clipboard~Clipboard},
  * * {@link module:enter/enter~Enter},
+ * * {@link module:select-all/selectall~SelectAll},
  * * {@link module:enter/shiftenter~ShiftEnter},
  * * {@link module:typing/typing~Typing},
  * * {@link module:undo/undo~Undo}.
@@ -37,7 +39,7 @@ export default class Essentials extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ Clipboard, Enter, ShiftEnter, Typing, Undo ];
+		return [ Clipboard, Enter, SelectAll, ShiftEnter, Typing, Undo ];
 	}
 
 	/**

--- a/tests/essentials.js
+++ b/tests/essentials.js
@@ -10,6 +10,7 @@ import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictest
 
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import SelectAll from '@ckeditor/ckeditor5-select-all/src/selectall';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
@@ -40,6 +41,7 @@ describe( 'Essentials preset', () => {
 	it( 'should load all its dependencies', () => {
 		expect( editor.plugins.get( Clipboard ) ).to.be.instanceOf( Clipboard );
 		expect( editor.plugins.get( Enter ) ).to.be.instanceOf( Enter );
+		expect( editor.plugins.get( SelectAll ) ).to.be.instanceOf( SelectAll );
 		expect( editor.plugins.get( ShiftEnter ) ).to.be.instanceOf( ShiftEnter );
 		expect( editor.plugins.get( Typing ) ).to.be.instanceOf( Typing );
 		expect( editor.plugins.get( Undo ) ).to.be.instanceOf( Undo );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added the [`SelectAll`](https://ckeditor.com/docs/ckeditor5/latest/api/module_select-all_selectall-SelectAll.html) plugin to the list of essential editor features (see ckeditor/ckeditor5#6536).

---

### Additional information

**Requires https://github.com/ckeditor/ckeditor5-select-all/pull/1.**
